### PR TITLE
Fix so reset works, plus addition of section resets

### DIFF
--- a/src/_includes/nextAssessmentButton.njk
+++ b/src/_includes/nextAssessmentButton.njk
@@ -3,7 +3,7 @@
 {% set foundEntry = false %}
 {%- for entry in navPages %}
   {% if nextEntry == true and foundEntry == false %}
-<a href="{{ window.location.href }}" id="resetSectionButton" role="button" draggable="false" class="govuk-button govuk-button--warning" data-module="govuk-button">
+<a href="#" id="resetSectionButton" role="button" draggable="false" class="govuk-button govuk-button--warning" data-module="govuk-button">
   Reset Section
 </a>
 <a href="{{ entry.url }}" role="button" draggable="false" class="govuk-button" data-module="govuk-button">

--- a/src/_includes/nextAssessmentButton.njk
+++ b/src/_includes/nextAssessmentButton.njk
@@ -1,13 +1,13 @@
-<a href="/assessment" id="resetButton" role="button" draggable="false" class="govuk-button govuk-button--warning" data-module="govuk-button">
-Reset
-</a>
 {% set navPages = collections.ordered | eleventyNavigation("Assessment") %}
 {% set nextEntry = false %}
 {% set foundEntry = false %}
 {%- for entry in navPages %}
   {% if nextEntry == true and foundEntry == false %}
+<a href="{{ window.location.href }}" id="resetSectionButton" role="button" draggable="false" class="govuk-button govuk-button--warning" data-module="govuk-button">
+  Reset Section
+</a>
 <a href="{{ entry.url }}" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
-Save and continue
+  Save and continue
 </a>
     {% set foundEntry = true %}
   {% endif %}
@@ -19,6 +19,9 @@ Save and continue
 {%- endfor %}
 
 {% if foundEntry == false %}
+<a href="{{ entry.url }}" id="resetButton" role="button" draggable="false" class="govuk-button govuk-button--warning" data-module="govuk-button">
+  Reset
+</a>
 <a href="/assessment/report" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
   Get report
 </a>

--- a/src/assets/cmm_assessment.js
+++ b/src/assets/cmm_assessment.js
@@ -58,8 +58,17 @@ function saveFormValues() {
   });
 }
 
-function clearFormValues(model) {
-  localStorage.removeItem(model);
+function clearFormValues(item) {
+  localStorage.removeItem(item);
+}
+
+function clearCategoryValues(storageItem, category) {
+  // Get the current data object in storage
+  var data = JSON.parse(localStorage.getItem(storageItem));
+  // Remove the current category value from the object
+  delete data[category];
+  // Set the updated data object as the new cmm link
+  localStorage.setItem(storageItem, JSON.stringify(data));
 }
 
 if (typeof module === "object")
@@ -68,15 +77,28 @@ if (typeof module === "object")
     setPropertySafely,
     saveFormValues,
     clearFormValues,
+    clearCategoryValues,
   };
 
 window.addEventListener("load", restoreFormValues);
 
 if (document.getElementById("resetButton"))
+  document.getElementById("resetButton").addEventListener("click", (e) =>
+    confirm("Are you sure you want to reset the entire report?")
+      ? clearFormValues("cmm") // to reset all, remove "cmm" object
+      : e.preventDefault(),
+  );
+
+if (document.getElementById("resetSectionButton")) {
+  // Get the name of the category, based on the current window href
+  const href = window.location.href.replace(/\/$/, "");
+  const category = href.substring(href.lastIndexOf("/") + 1);
+
   document
-    .getElementById("resetButton")
+    .getElementById("resetSectionButton")
     .addEventListener("click", (e) =>
-      confirm("Are you sure you want to reset the entire report?")
-        ? clearFormValues()
+      confirm("Are you sure you want to reset this section?")
+        ? clearCategoryValues("cmm", category)
         : e.preventDefault(),
     );
+}

--- a/src/assets/cmm_assessment.js
+++ b/src/assets/cmm_assessment.js
@@ -89,15 +89,15 @@ if (document.getElementById("resetButton"))
     );
 
 if (document.getElementById("resetSectionButton")) {
-  // Get the name of the category, based on the current window href
-  const href = window.location.href.replace(/\/$/, "");
-  const category = href.substring(href.lastIndexOf("/") + 1);
+  // Take any element of the document input (we take the first)
+  // Then split it by _ to [model, section, question], taking the section
+  const section = document.querySelectorAll("input")[0].name.split("_")[1];
 
   document
     .getElementById("resetSectionButton")
     .addEventListener("click", (e) =>
       confirm("Are you sure you want to reset this section?")
-        ? clearCategoryValues("cmm", category)
+        ? clearCategoryValues("cmm", section)
         : e.preventDefault(),
     );
 }

--- a/src/assets/cmm_assessment.js
+++ b/src/assets/cmm_assessment.js
@@ -63,11 +63,8 @@ function clearFormValues(item) {
 }
 
 function clearCategoryValues(storageItem, category) {
-  // Get the current data object in storage
   var data = JSON.parse(localStorage.getItem(storageItem));
-  // Remove the current category value from the object
   delete data[category];
-  // Set the updated data object as the new cmm link
   localStorage.setItem(storageItem, JSON.stringify(data));
 }
 
@@ -83,11 +80,13 @@ if (typeof module === "object")
 window.addEventListener("load", restoreFormValues);
 
 if (document.getElementById("resetButton"))
-  document.getElementById("resetButton").addEventListener("click", (e) =>
-    confirm("Are you sure you want to reset the entire report?")
-      ? clearFormValues("cmm") // to reset all, remove "cmm" object
-      : e.preventDefault(),
-  );
+  document
+    .getElementById("resetButton")
+    .addEventListener("click", (e) =>
+      confirm("Are you sure you want to reset the entire report?")
+        ? clearFormValues("cmm")
+        : e.preventDefault(),
+    );
 
 if (document.getElementById("resetSectionButton")) {
   // Get the name of the category, based on the current window href

--- a/tests/cmm_assessment.test.js
+++ b/tests/cmm_assessment.test.js
@@ -122,3 +122,25 @@ describe("clearFormValues", () => {
     expect(localStorage.getItem("bar")).toEqual("foo"));
   it.todo("should ask for confirmation before acting");
 });
+
+describe("clearCategoryValues", () => {
+  beforeAll(() => {
+    localStorage.setItem(
+      "foo",
+      JSON.stringify({
+        categoryA: "a",
+        categoryB: "b",
+      }),
+    );
+    localStorage.setItem("bar", "foo");
+    m.clearCategoryValues("foo", "categoryA");
+  });
+  afterAll(() => localStorage.clear());
+
+  it("should update the object in localStorage", () =>
+    expect(localStorage.getItem("foo")).toEqual(
+      JSON.stringify({ categoryB: "b" }),
+    ));
+  it("should not remove other items from localStorage", () =>
+    expect(localStorage.getItem("bar")).toEqual("foo"));
+});


### PR DESCRIPTION
Original reset didn't clear local storage as was receiving an empty identifier ("model"), so instead updated it so that reset removes the entire cmm model. 

I've also updated the reset at the bottom of each section to use a 'section reset' function, which takes the local storage 'cmm' object, removes the particular section data from it (taken from url), and resets the cmm object with the retrated data. This means the 'hard' reset is only on the first page.

![before-section-reset](https://github.com/co-cddo/cloudmaturity/assets/28672846/b52be736-6fa5-4343-adb1-e0e73948f1a0)
![during-section-reset](https://github.com/co-cddo/cloudmaturity/assets/28672846/8d483f32-da13-49c0-b544-80fb5662be88)
![after-section-reset](https://github.com/co-cddo/cloudmaturity/assets/28672846/8081879c-ff01-43c7-a20c-05fc4251547c)
