### PR TITLE
fix: add missing eleventyNavigation to report.md

### DIFF
--- a/src/assessment/report.md
+++ b/src/assessment/report.md
@@ -2,6 +2,8 @@
 layout: sub-navigation
 order: 2
 title: Report
+eleventyNavigation:
+  parent: Assessment
 ---
 
 {% from "govuk/components/button/macro.njk" import govukButton %}


### PR DESCRIPTION
## Summary

- Fixed broken left-hand navigation on production where assessment sub-items were missing
- Added required `eleventyNavigation` configuration to `report.md` frontmatter

## Problem

On production, the left-hand navigation only showed "Report" instead of all the assessment sub-items:
- Cost & Sustainability
- Data  
- Governance
- Operations
- People
- Security
- Technology
- Report Compilation

## Root Cause

The `src/assessment/report.md` file was missing the `eleventyNavigation` configuration in its frontmatter. All other assessment pages had:

```yaml
eleventyNavigation:
  parent: Assessment
```

But `report.md` only had `order: 2` without the navigation configuration.

## Solution

Added the missing `eleventyNavigation` configuration to properly register the Report page as a child of the Assessment section in the Eleventy navigation system.

## Test Plan

- [x] Built locally with `PATH_PREFIX=/cloudmaturity/` 
- [x] Verified navigation HTML shows all sub-items in nested list
- [ ] Deploy to production and verify navigation displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)